### PR TITLE
enh: Use __name__ instead of hardcoded "mars.services" in `_normalize_modules`.

### DIFF
--- a/mars/services/cluster/file_logger.py
+++ b/mars/services/cluster/file_logger.py
@@ -31,7 +31,7 @@ class FileLoggerActor(mo.Actor):
         file_path = os.environ.get(MARS_LOG_PATH_KEY)
         # other situations: start cluster not from cmdline
         if file_path is None:
-            logger.warning("Env {0} is not set!".format(MARS_LOG_PATH_KEY))
+            logger.debug("Env {0} is not set!".format(MARS_LOG_PATH_KEY))
             mars_tmp_dir = tempfile.mkdtemp(prefix=MARS_TMP_DIR_PREFIX)
             _, file_path = tempfile.mkstemp(prefix=MARS_LOG_PREFIX, dir=mars_tmp_dir)
             os.environ[MARS_LOG_PATH_KEY] = file_path

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -134,7 +134,7 @@ def _normalize_modules(modules: _ModulesType):
         modules = [modules]
     else:
         modules = list(modules)
-    modules = [__name__.rsplit('.', 1)[0]] + modules
+    modules = [__name__.rsplit(".", 1)[0]] + modules
     return modules
 
 

--- a/mars/services/core.py
+++ b/mars/services/core.py
@@ -134,7 +134,7 @@ def _normalize_modules(modules: _ModulesType):
         modules = [modules]
     else:
         modules = list(modules)
-    modules = ["mars.services"] + modules
+    modules = [__name__.rsplit('.', 1)[0]] + modules
     return modules
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Use `__name__` instead of hardcoded "mars.services" in `_normalize_modules`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
