### PR TITLE
enh: Support passing mars objects when call df.map_chunk

### DIFF
--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes
-from ...core import recursive_tile, get_output_types
+from ...core import recursive_tile, get_output_types, ENTITY_TYPE, CHUNK_TYPE
 from ...core.custom_log import redirect_custom_log
 from ...serialization.serializables import (
     KeyField,
@@ -25,7 +25,13 @@ from ...serialization.serializables import (
     DictField,
     BoolField,
 )
-from ...utils import enter_current_session, has_unknown_shape, quiet_stdio
+from ...utils import (
+    enter_current_session,
+    has_unknown_shape,
+    quiet_stdio,
+    find_objects,
+    replace_objects,
+)
 from ..operands import DataFrameOperand, DataFrameOperandMixin, OutputType
 from ..utils import (
     build_df,
@@ -88,6 +94,12 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
 
     def _set_inputs(self, inputs):
         super()._set_inputs(inputs)
+        old_inputs = find_objects(self._args, ENTITY_TYPE) + find_objects(
+            self._kwargs, ENTITY_TYPE
+        )
+        mapping = {o: n for o, n in zip(old_inputs, self._inputs[1:])}
+        self._args = replace_objects(self._args, mapping)
+        self._kwargs = replace_objects(self._kwargs, mapping)
         self._input = self._inputs[0]
 
     def _infer_attrs_by_call(self, df_or_series):
@@ -171,9 +183,14 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                         "if output_type='dataframe'"
                     )
 
+        inputs = (
+            [df_or_series]
+            + find_objects(self.args, ENTITY_TYPE)
+            + find_objects(self.kwargs, ENTITY_TYPE)
+        )
         if output_type == OutputType.series:
             return self.new_series(
-                [df_or_series],
+                inputs,
                 dtype=dtypes.iloc[0],
                 shape=shape,
                 index_value=index_value,
@@ -183,7 +200,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
             # dataframe
             columns_value = parse_index(dtypes.index, store_data=True)
             return self.new_dataframe(
-                [df_or_series],
+                inputs,
                 shape=shape,
                 dtypes=dtypes,
                 index_value=index_value,
@@ -200,6 +217,10 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                 yield
             # if input is a DataFrame, make sure 1 chunk on axis columns
             inp = yield from recursive_tile(inp.rechunk({1: inp.shape[1]}))
+        arg_input_chunks = []
+        for other_inp in op.inputs[1:]:
+            other_inp = yield from recursive_tile(other_inp.rechunk(other_inp.shape))
+            arg_input_chunks.append(other_inp.chunks[0])
 
         out_chunks = []
         nsplits = [[]] if out.ndim == 1 else [[], [out.shape[1]]]
@@ -214,7 +235,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                     shape = (chunk.shape[0], out.shape[1])
                 index_value = parse_index(pd_out_index, chunk, op.key)
                 out_chunk = chunk_op.new_chunk(
-                    [chunk],
+                    [chunk] + arg_input_chunks,
                     shape=shape,
                     dtypes=out.dtypes,
                     index_value=index_value,
@@ -230,7 +251,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                     shape = (chunk.shape[0],)
                 index_value = parse_index(pd_out_index, chunk, op.key)
                 out_chunk = chunk_op.new_chunk(
-                    [chunk],
+                    [chunk] + arg_input_chunks,
                     shape=shape,
                     index_value=index_value,
                     name=out.name,
@@ -264,7 +285,12 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
         kwargs = op.kwargs or dict()
         if op.with_chunk_index:
             kwargs["chunk_index"] = out.index
-        ctx[out.key] = op.func(inp, *op.args, **kwargs)
+        args = op.args or tuple()
+        chunks = find_objects(args, CHUNK_TYPE) + find_objects(kwargs, CHUNK_TYPE)
+        mapping = {chunk: ctx[chunk.key] for chunk in chunks}
+        args = replace_objects(args, mapping)
+        kwargs = replace_objects(kwargs, mapping)
+        ctx[out.key] = op.func(inp, *args, **kwargs)
 
 
 def map_chunk(df_or_series, func, args=(), **kwargs):

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1881,6 +1881,25 @@ def test_map_chunk_execution(setup):
     expected = raw_s + 1 + np.arange(10) // 5
     pd.testing.assert_series_equal(result, expected)
 
+    # test args or kwargs with mars objects
+    df = from_pandas_df(raw, chunk_size=5)
+
+    def f6(df, mars_df):
+        return df + mars_df.sum()
+
+    df_arg = from_pandas_df(raw, chunk_size=6)
+    r = df.map_chunk(f6, args=(df_arg,), output_type="dataframe", dtypes=df.dtypes)
+    expected = raw + raw.sum()
+    result = r.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
+    df = from_pandas_df(raw, chunk_size=5)
+    df_arg = from_pandas_df(raw, chunk_size=6)
+    r = df.map_chunk(f6, mars_df=df_arg, output_type="dataframe", dtypes=df.dtypes)
+    expected = raw + raw.sum()
+    result = r.execute().fetch()
+    pd.testing.assert_frame_equal(result, expected)
+
 
 def test_cartesian_chunk_execution(setup):
     rs = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Support passing mars objects when call `df.map_chunk`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
