### PR TITLE
Fix: `series.drop_duplicates()` failed

### DIFF
--- a/mars/dataframe/base/_duplicate.py
+++ b/mars/dataframe/base/_duplicate.py
@@ -160,7 +160,7 @@ class DuplicateOperand(MapReduceOperand, DataFrameOperandMixin):
                 if out_chunk_size > 1 and method == "tree":
                     # for tree, chunks except last one should be dataframes,
                     chunk_op._output_types = (
-                        [OutputType.dataframe]
+                        concat_chunk.op.output_types
                         if out_chunk_size > 1
                         else out.op.output_types
                     )

--- a/mars/dataframe/base/drop_duplicates.py
+++ b/mars/dataframe/base/drop_duplicates.py
@@ -202,6 +202,7 @@ class DataFrameDropDuplicates(DuplicateOperand):
         elif out.op.output_types[0] == OutputType.series:
             assert inp.shape[1] == 1
             ret = inp.iloc[:, 0]
+            ret.name = out.name
         else:
             ret = inp
 

--- a/mars/dataframe/base/duplicated.py
+++ b/mars/dataframe/base/duplicated.py
@@ -159,7 +159,7 @@ class DataFrameDuplicated(DuplicateOperand):
         duplicated_filter = ~inp.iloc[:, -1]
         duplicates = inp.loc[duplicated_filter]
         dup_on_duplicated = cls._duplicated(duplicates, op)
-        result.iloc[duplicated_filter.values, -1] = dup_on_duplicated
+        result.iloc[duplicated_filter.to_numpy().nonzero()[0], -1] = dup_on_duplicated
         duplicated = result.iloc[:, -1]
         result.iloc[duplicated.values, :-1] = None
         ctx[op.outputs[0].key] = result

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
     pa = None
 
 from ....config import options, option_context
-from ....dataframe import DataFrame
+from ....dataframe import DataFrame, Series
 from ....tensor import arange, tensor
 from ....tensor.random import rand
 from ....tests.core import require_cudf
@@ -1680,6 +1680,15 @@ def test_drop_duplicates(setup):
         pd.testing.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("method", ["tree", "shuffle"])
+def test_series_drop_duplicates(setup, method):
+    raw = pd.Series(np.random.randint(5, size=50))
+    s = Series(raw, chunk_size=10)
+    r = s.drop_duplicates(method=method).execute()
+    result = r.execute().fetch()
+    pd.testing.assert_series_equal(result, raw.drop_duplicates())
+
+
 def test_duplicated(setup):
     # test dataframe drop
     rs = np.random.RandomState(0)
@@ -1744,6 +1753,15 @@ def test_duplicated(setup):
                             raise AssertionError(
                                 f"failed when method={method}, keep={keep}"
                             ) from e
+
+
+@pytest.mark.parametrize("method", ["tree", "shuffle"])
+def test_series_duplicated(setup, method):
+    raw = pd.Series(np.random.randint(5, size=50))
+    s = Series(raw, chunk_size=10)
+    r = s.duplicated(method=method).execute()
+    result = r.execute().fetch()
+    pd.testing.assert_series_equal(result, raw.duplicated())
 
 
 def test_memory_usage_execution(setup):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixed `series.drop duplicates()`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #52 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
